### PR TITLE
Update python requirements to allow use with any >=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,5 @@ setuptools.setup(
         "textnorm",
         "validators",
     ],
-    python_requires=">=3.10.2",
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
Tied to https://github.com/isawnyu/pleiades_search_api/pull/1 , the requirement of python3.10.2 limits the usability of this library, and isn't necessary for the execution of this code.